### PR TITLE
Fix dropping socket connecitons on arrival

### DIFF
--- a/MJPEGWriter.cpp
+++ b/MJPEGWriter.cpp
@@ -5,6 +5,7 @@ MJPEGWriter::Listener()
 {
     fd_set rread;
     SOCKET maxfd;
+    this->open();
     while (true)
     {
         rread = master;

--- a/MJPEGWriter.cpp
+++ b/MJPEGWriter.cpp
@@ -6,6 +6,7 @@ MJPEGWriter::Listener()
     fd_set rread;
     SOCKET maxfd;
     this->open();
+    pthread_mutex_unlock(&mutex_writer);
     while (true)
     {
         rread = master;
@@ -54,6 +55,8 @@ MJPEGWriter::Listener()
 void
 MJPEGWriter::Writer()
 {
+    pthread_mutex_lock(&mutex_writer);
+    pthread_mutex_unlock(&mutex_writer);
     while (this->isOpened())
     {
         pthread_t threads[NUM_CONNECTIONS];

--- a/MJPEGWriter.h
+++ b/MJPEGWriter.h
@@ -141,6 +141,7 @@ public:
     }
 
     void start(){
+        pthread_mutex_lock(&mutex_writer);
         pthread_create(&thread_listen, NULL, this->listen_Helper, this);
         pthread_create(&thread_write, NULL, this->writer_Helper, this);
     }

--- a/MJPEGWriter.h
+++ b/MJPEGWriter.h
@@ -47,6 +47,7 @@ class MJPEGWriter{
     pthread_mutex_t mutex_cout = PTHREAD_MUTEX_INITIALIZER;
     pthread_mutex_t mutex_writer = PTHREAD_MUTEX_INITIALIZER;
     Mat lastFrame;
+    int port;
 
     int _write(int sock, char *s, int len)
     {
@@ -91,11 +92,12 @@ public:
         : sock(INVALID_SOCKET)
         , timeout(TIMEOUT_M)
         , quality(90)
+	, port(port)
     {
         signal(SIGPIPE, SIG_IGN);
         FD_ZERO(&master);
-        if (port)
-            open(port);
+        // if (port)
+        //     open(port);
     }
 
     ~MJPEGWriter()
@@ -111,7 +113,7 @@ public:
         return false;
     }
 
-    bool open(int port)
+    bool open()
     {
         sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 


### PR DESCRIPTION
It seems that if socket is initialized outside listener thread, connections are closed on arrival. This patch adds the port number as an object attribute and calls port open() function inside listener thread.