### PR TITLE
Enable address reuse https://stackoverflow.com/questions/14388706/how…

### DIFF
--- a/MJPEGWriter.h
+++ b/MJPEGWriter.h
@@ -131,6 +131,8 @@ public:
     bool open()
     {
         sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        int yes = 1;
+		setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
 
         SOCKADDR_IN address;
         address.sin_addr.s_addr = INADDR_ANY;


### PR DESCRIPTION
…-do-so-reuseaddr-and-so-reuseport-differ

> The question is, how does the system treat a socket in state TIME_WAIT? If SO_REUSEADDR is not set, a socket in state TIME_WAIT is considered to still be bound to the source address and port and any attempt to bind a new socket to the same address and port will fail until the socket has really been closed. So don't expect that you can rebind the source address of a socket immediately after closing it. In most cases this will fail. However, if SO_REUSEADDR is set for the socket you are trying to bind, another socket bound to the same address and port in state TIME_WAIT is simply ignored, after all its already "half dead", and your socket can bind to exactly the same address without any problem. In that case it plays no role that the other socket may have exactly the same address and port.

https://stackoverflow.com/questions/14388706/how-do-so-reuseaddr-and-so-reuseport-differ

